### PR TITLE
Ignore CS5001 error in compilation

### DIFF
--- a/CHash2DaScript/Program.cs
+++ b/CHash2DaScript/Program.cs
@@ -41,6 +41,7 @@ namespace Main
                 result += "// Compilation errors:\n";
                 foreach (var error in errors)
                 {
+                    if (error.Id == "CS5001") continue; // entry point not found
                     var error_text = $"{error.Id}: {error.GetMessage()} at {error.Location}";
                     result += $"//{error_text}\n";
                 }

--- a/CHash2DaScript/Test/test.das
+++ b/CHash2DaScript/Test/test.das
@@ -1,5 +1,4 @@
 // Compilation errors:
-//CS5001: Program does not contain a static 'Main' method suitable for an entry point at None
 
 module test
 


### PR DESCRIPTION
This pull request includes changes to ignore the CS5001 error in compilation, which occurs when the program does not contain a static 'Main' method suitable for an entry point. 